### PR TITLE
Improve readme setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,5 @@ Make sure you have node.js installed first.
 1. Open Terminal and navigate to the project root directory,
 2. Run `npm install`,
 3. Run `npm run build`,
-4. Go to `public/` directory,
-5. Start a simple HTTP server serving files, for example: `python -m SimpleHTTPServer 8000`,
-6. Open http://localhost:8000 in a browser.
+4. Run `npm run serve`
+5. Open http://localhost:4000 in a browser.

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "version": "0.0.0",
   "private": true,
   "hexo": {
-    "version": "3.7.1"
+    "version": "3.8.0"
   },
   "scripts": {
     "clean": "rm -rf public/*",
     "build": "hexo generate",
     "eslint": "eslint .",
-    "deploy": "hexo deploy"
+    "deploy": "hexo deploy",
+    "serve": "hexo serve"
   },
   "dependencies": {
     "cheerio": "^0.20.0",


### PR DESCRIPTION
hexo can serve the site as well, using a separate web-server isn't necessary. I added a script to the package, and updated the read me, making it shorter and simper and requiring less externalities (like the simple python server).